### PR TITLE
brutal fixing of the redundant field

### DIFF
--- a/galaxy2galaxy/data_generators/cosmos.py
+++ b/galaxy2galaxy/data_generators/cosmos.py
@@ -98,7 +98,7 @@ class Img2imgCosmos(galsim_utils.GalsimProblem):
     cat_param = append_fields(cat_param, 'disk_flux_log10', np.where(cat_param['use_bulgefit'] ==1, np.log10(cat_param['flux'][:,2]), np.log10(cat_param['flux'][:,0])))
 
     # Parameters for a single component fit
-#     cat_param = append_fields(cat_param, 'bulge_flux_log10', np.log10(sparams[:,0]))
+    cat_param = append_fields(cat_param, 'sersic_flux_log10', np.log10(sparams[:,0]))
     cat_param = append_fields(cat_param, 'sersic_q', sparams[:,3])
     cat_param = append_fields(cat_param, 'sersic_hlr', sparams[:,1])
     cat_param = append_fields(cat_param, 'sersic_n', sparams[:,2])

--- a/galaxy2galaxy/data_generators/cosmos.py
+++ b/galaxy2galaxy/data_generators/cosmos.py
@@ -98,7 +98,7 @@ class Img2imgCosmos(galsim_utils.GalsimProblem):
     cat_param = append_fields(cat_param, 'disk_flux_log10', np.where(cat_param['use_bulgefit'] ==1, np.log10(cat_param['flux'][:,2]), np.log10(cat_param['flux'][:,0])))
 
     # Parameters for a single component fit
-    cat_param = append_fields(cat_param, 'bulge_flux_log10', np.log10(sparams[:,0]))
+#     cat_param = append_fields(cat_param, 'bulge_flux_log10', np.log10(sparams[:,0]))
     cat_param = append_fields(cat_param, 'sersic_q', sparams[:,3])
     cat_param = append_fields(cat_param, 'sersic_hlr', sparams[:,1])
     cat_param = append_fields(cat_param, 'sersic_n', sparams[:,2])


### PR DESCRIPTION
I've done the brutal fixing for the problem concerning the redundancy of the flux field. I think of two way to do that better : 

1) If there is a different field on the cosmos cat that could be used in the single component part of the function, using it instead of the same as the one used in the 2 component fit.

2) Include a if statement (maybe with a new hyperparameter nb_component ?) to add only once the flux, with the correct definition depending on the number of component. 